### PR TITLE
Add new option for button kind

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -119,6 +119,7 @@
   id | String | DOM node id in which the Amazon login button will be placed
   [type] | String | 'large' (default), 'small' [See button guide][button-guide]
   [color] | String | 'Gold' (default), 'LightGray', 'DarkGray' [See button guide][button-guide]
+  [kind] | String | 'pay' (default), 'login' [See button guide][button-guide]
 
 #### wallet options
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,12 @@ PayWithAmazon.prototype.configure = function (opts) {
   if (typeof opts.consent === 'string') opts.consent = { id: opts.consent };
   if (typeof opts.addressBook === 'string') opts.addressBook = { id: opts.addressBook };
 
-  opts.button.type = opts.button.type === 'small' ? 'Pay' : 'PwA';
+  if (opts.button.kind === 'login') {
+    opts.button.type = opts.button.type === 'small' ? 'Login' : 'LwA';
+  } else {
+    opts.button.type = opts.button.type === 'small' ? 'Pay' : 'PwA';
+  }
+
   opts.button.color = opts.button.color || 'Gold';
 
   if (opts.wallet.width || opts.wallet.height) {


### PR DESCRIPTION
If the value is set to 'login', it will use the "Login with Amazon" button instead of the "Pay with Amazon" button.

Approvers: @chrissrogers 

Tests:
- Set kind param to 'login' when configuring button
- Verify that button is the Login version and the Pay version