### PR TITLE
Add support for Amazon Pay EU

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,20 @@
   });
   ```
 
+  To add EU support, simply include the `region` parameter:
+
+  ```js
+  var payWithAmazon = new PayWithAmazon({
+    sellerId: 'ABC',
+    clientId: 'XYZ',
+    button: { id: 'pay-with-amazon', [type], [color] },
+    addressBook: { id: 'address-book', [width], [height] },
+    wallet: { id: 'wallet', [width], [height] },
+    consent: { id: 'consent', [width], [height] },
+    region: 'eu'
+  });
+  ```
+
   For this example, the `<body>` would need to contain the following elements:
 
   ```html

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ module.exports = PayWithAmazon;
  *     button: { id: 'pay-with-amazon' },
  *     addressBook: { id: 'address-book' [, width: 400 [, height: 260]]},
  *     wallet: { id: 'wallet' [, width: 400 [, height: 260]]},
- *     consent: { id: 'consent' [, width: 400 [, height: 140]]}
+ *     consent: { id: 'consent' [, width: 400 [, height: 140]]},
+ *     region: 'eu'
  *   });
  *
  * @param {Object} opts
@@ -52,6 +53,7 @@ module.exports = PayWithAmazon;
  * @param {Number} [opts.consent.width]
  * @param {Number} [opts.consent.height]
  * @param {String} [opts.openedClass]
+ * @param {String} [opts.region]
  */
 
 function PayWithAmazon (opts) {
@@ -75,10 +77,7 @@ function PayWithAmazon (opts) {
     this.init();
   } else {
     document.write('<script src="'
-      + 'https://static-na.payments-amazon.com/OffAmazonPayments/us'
-      + (this.config.production ? '' : '/sandbox')
-      + '/js/Widgets.js?sellerId='
-      + this.config.sellerId
+      + this.getAssetPath()
       + '"></script>');
 
     window.onAmazonLoginReady = this.init;
@@ -176,6 +175,25 @@ PayWithAmazon.prototype.init = function () {
     self.initButton();
   }
 };
+
+/**
+ * Returns the url for Amazon widgets based on region url param
+ *
+ * @return {String} url
+ */
+PayWithAmazon.prototype.getAssetPath = function () {
+  var env = this.config.production ? '' : '/sandbox';
+  if (this.config.region == 'eu') {
+    return 'https://static-eu.payments-amazon.com/OffAmazonPayments/eur'
+      + env
+      + '/lpa/js/Widgets.js?sellerId='
+      + this.config.sellerId;
+  }
+  return 'https://static-na.payments-amazon.com/OffAmazonPayments/us'
+      + env
+      + '/js/Widgets.js?sellerId='
+      + this.config.sellerId;
+}
 
 /**
  * Returns an object describing the customer state


### PR DESCRIPTION
Usage:
```
      var payWithAmazon = new PayWithAmazon({
        clientId: '<your_eu_client_id>,
        sellerId: '<your_eu_seller_id>',
        button: 'pay-with-amazon',
        wallet: { id: 'wallet', width: 400 },
        consent: { id: 'consent', width: 400 },
        addressBook: { id: 'address-book', width: 400 },
        region: 'eu'
      }).on('change', notify);
```