### PR TITLE
Accept additional authorization scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ import Emitter from 'component-emitter';
  * @param {Number} [opts.consent.height]
  * @param {String} [opts.openedClass]
  * @param {String} [opts.region] 'us' (default), 'eu', 'uk'
- * @param {Array|String} [opts.authorizationScope] [] (default)
+ * @param {Array|String} [opts.additionalLoginScope] [] (default)
  */
 
 export default class PayWithAmazon extends Emitter {
@@ -110,7 +110,7 @@ export default class PayWithAmazon extends Emitter {
     if (typeof opts.wallet === 'string') opts.wallet = { id: opts.wallet };
     if (typeof opts.consent === 'string') opts.consent = { id: opts.consent };
     if (typeof opts.addressBook === 'string') opts.addressBook = { id: opts.addressBook };
-    if (typeof opts.authorizationScope === 'string') opts.authorizationScope = [opts.authorizationScope];
+    if (typeof opts.additionalLoginScope === 'string') opts.additionalLoginScope = [opts.additionalLoginScope];
 
     if (opts.button.kind === 'login') {
       opts.button.type = opts.button.type === 'small' ? 'Login' : 'LwA';
@@ -143,7 +143,7 @@ export default class PayWithAmazon extends Emitter {
 
     opts.production = typeof opts.production === 'boolean' ? opts.production : false;
     opts.openedClass = opts.openedClass || 'open';
-    opts.authorizationScope = opts.authorizationScope || [];
+    opts.additionalLoginScope = opts.additionalLoginScope || [];
 
     this.config = opts;
   }
@@ -220,8 +220,8 @@ export default class PayWithAmazon extends Emitter {
     var self = this;
     var type = this.config.button.type;
     var color = this.config.button.color;
-    var defaultScope = ['profile', 'payments:widget', 'payments:shipping_address'];
-    var scope = defaultScope.concat(this.config.authorizationScope).join(' ');
+    var requiredScope = ['profile', 'payments:widget', 'payments:shipping_address'];
+    var scope = requiredScope.concat(this.config.additionalLoginScope).join(' ');
 
     this.widgets.button = new window.OffAmazonPayments.Button(this.config.button.id, this.config.sellerId, {
       type: type,

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const ASSET_BASE_PATH = 'https://static-na.payments-amazon.com/OffAmazonPayments
  * @param {Number} [opts.consent.height]
  * @param {String} [opts.openedClass]
  * @param {String} [opts.region] 'us' (default), 'eu', 'uk'
+ * @param {Array|String} [opts.authorizationScope] [] (default)
  */
 
 export default class PayWithAmazon extends Emitter {
@@ -105,6 +106,7 @@ export default class PayWithAmazon extends Emitter {
     if (typeof opts.wallet === 'string') opts.wallet = { id: opts.wallet };
     if (typeof opts.consent === 'string') opts.consent = { id: opts.consent };
     if (typeof opts.addressBook === 'string') opts.addressBook = { id: opts.addressBook };
+    if (typeof opts.authorizationScope === 'string') opts.authorizationScope = [opts.authorizationScope];
 
     if (opts.button.kind === 'login') {
       opts.button.type = opts.button.type === 'small' ? 'Login' : 'LwA';
@@ -137,6 +139,7 @@ export default class PayWithAmazon extends Emitter {
 
     opts.production = typeof opts.production === 'boolean' ? opts.production : false;
     opts.openedClass = opts.openedClass || 'open';
+    opts.authorizationScope = opts.authorizationScope || [];
 
     this.config = opts;
   }
@@ -213,13 +216,15 @@ export default class PayWithAmazon extends Emitter {
     var self = this;
     var type = this.config.button.type;
     var color = this.config.button.color;
+    var defaultScope = ['profile', 'payments:widget', 'payments:shipping_address'];
+    var scope = defaultScope.concat(this.config.authorizationScope).join(' ');
 
     this.widgets.button = new window.OffAmazonPayments.Button(this.config.button.id, this.config.sellerId, {
       type: type,
       color: color,
       authorization: function () {
         var opts = {
-          scope: 'profile payments:widget payments:shipping_address',
+          scope: scope,
           popup: true
         };
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 import Emitter from 'component-emitter';
 
-const ASSET_BASE_PATH = 'https://static-na.payments-amazon.com/OffAmazonPayments/us';
-
 /**
  * Off Amazon Payments wrapper
  *
@@ -78,10 +76,16 @@ export default class PayWithAmazon extends Emitter {
   version = '2.0.1';
 
   get assetPath () {
-    const { production } = this.config;
-    let basePath = ASSET_BASE_PATH;
-    if (production) basePath += '/sandbox';
-    return `${basePath}/js/Widgets.js?sellerId=${this.config.sellerId}`;
+    const { production, region } = this.config;
+    const env = production ? '' : '/sandbox';
+
+    if (region === 'eu') {
+      return `https://static-eu.payments-amazon.com/OffAmazonPayments/eur${env}/lpa/js/Widgets.js?sellerId=${this.config.sellerId}`;
+    } else if (region === 'uk') {
+      return `https://static-eu.payments-amazon.com/OffAmazonPayments/gbp${env}/lpa/js/Widgets.js?sellerId=${this.config.sellerId}`;
+    } else {
+      return `https://static-na.payments-amazon.com/OffAmazonPayments/us${env}/js/Widgets.js?sellerId=${this.config.sellerId}`;
+    }
   }
 
   /**


### PR DESCRIPTION
Proposed change is as follows:

```js
  // For recurring transactions, address book omitted
  var payWithAmazon = new PayWithAmazon({
    clientId: 'amzn1.application-oa2-client.127b0a3e68334641a3e4e129f686d140',
    sellerId: 'A35095BGBGQR66',
    button: 'pay-with-amazon',
    wallet: { id: 'wallet', width: 400 },
    consent: { id: 'consent', width: 400 },
    additionalLoginScope: 'postal_code' // Alternate: ['postal_code']
  })
```

### Amazon Docs
https://developer.amazon.com/docs/login-with-amazon/javascript-sdk-reference.html#scope
https://developer.amazon.com/docs/login-with-amazon/requesting-scopes-as-essential-voluntary.html
https://developer.amazon.com/docs/login-with-amazon/customer-profile.html

### RFC

1. Name
2. Accept array or string
3. Documentation
4. Testing