### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,6 @@ on:
       - released
 name: Demo Page
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: Publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,12 +3,16 @@ on:
     types:
       - released
 name: Demo Page
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.3
 
     - name: Build Library and Docs
       run: make build_pages
@@ -16,8 +20,8 @@ jobs:
     - name: Deploy
       if: success()
       # use the specific sha of 3rd party libraries for security reasons https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
-      # Using tag v2.3.0
-      uses: crazy-max/ghaction-github-pages@b8f8d291c97fe0edd9fb4ee73018163593418e8f
+      # Using tag v5.0.0
+      uses: crazy-max/ghaction-github-pages@1d6ee9b181a81033a16bd707a1401afa978daab4
       with:
         target_branch: gh-pages
         build_dir: ./pages

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,9 +10,6 @@ on:
       - master
       - qa
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,10 +10,13 @@ on:
       - master
       - qa
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
       - uses: stefanoeb/eslint-action@1.0.2
         continue-on-error: true


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20 and will force Node.js 24 for all JavaScript actions starting June 2026. This repo had two workflow files using actions that run on Node.js 12 and Node.js 16, both of which are below the minimum threshold.

See the [GitHub blog announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for details.

### Fix
Upgraded all affected JavaScript actions to their latest Node.js 24-compatible versions:
- `actions/checkout` — v2 / v3 → v6.0.3 (node24)
- `crazy-max/ghaction-github-pages` — v2.3.0 (SHA-pinned) → v5.0.0 (SHA-pinned, node24)

SHA pinning preserved on `crazy-max/ghaction-github-pages` per the existing security policy in the file. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` flag was added for CI validation and will be removed in a follow-up commit before merge.

### Files Changed
- `.github/workflows/eslint.yml` — bumped `actions/checkout` v3 → v6.0.3; added FORCE flag
- `.github/workflows/docs.yml` — bumped `actions/checkout` v2 → v6.0.3 and `crazy-max/ghaction-github-pages` v2.3.0 → v5.0.0 (SHA-pinned); added FORCE flag

## Testing
CI validation via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` flag added in this PR. No workaround items — all affected actions have Node.js 24-compatible releases available.